### PR TITLE
Local Class Creation

### DIFF
--- a/src/scripts/DbHelper.js
+++ b/src/scripts/DbHelper.js
@@ -7,12 +7,8 @@ class DBHelper{
     return `/data/appData.json`;
   }
 
-  static get STUDENT_MODEL(){
-    return {
-      studentId: undefined,
-      studentName: undefined,
-    }
-  }
+
+  // models for data from server
 
   static get CLASS_MODEL(){
     return {
@@ -41,6 +37,39 @@ class DBHelper{
     }
   }
 
+  static get STUDENT_MODEL(){
+    return {
+      studentId: undefined,
+      studentName: undefined,
+    }
+  }
+
+  // models for locally stored class/lesson/students
+
+  static get OFFLINE_CLASS_MODEL(){
+    return{
+      className: undefined,
+      attachedStudents:[]
+    }
+  }
+
+  static get OFFLINE_LESSON_MODEL(){
+    return{
+      lessonName: undefined,
+      lessonDate: undefined,
+      attachedClass:undefined,
+      attachedStudents: [],
+    }
+  }
+
+  static get OFFLINE_STUDENT_MODEL(){
+    return{
+      studentName: undefined
+    }
+  }
+
+  // database table names
+
   static get RECORDER_DB_NAME(){
     return 'recorder-db'
   }
@@ -61,6 +90,18 @@ class DBHelper{
     return 'lesson-store'
   }
 
+  static get OFFLINE_CLASS_STORE_NAME(){
+    return 'offline-class-store';
+  }
+
+  static get OFFLINE_LESSON_STORE_NAME(){
+    return 'offline-lesson-store';
+  }
+
+  static get OFFLINE_STUDENT_STORE_NAME(){
+    return 'offline-student-store';
+  }
+
   constructor(){
     // popualte the database
     this.dbPromise = idb.open(DBHelper.RECORDER_DB_NAME,1,(upgradeDb)=>{
@@ -71,15 +112,27 @@ class DBHelper{
           clipStore.createIndex('by-class','classId');
           clipStore.createIndex('by-lesson','lessonId');
 
-          var studentStore = upgradeDb.createObjectStore( DBHelper.STUDENT_STORE_NAME, {keyPath: 'studentId'});
-          studentStore.createIndex('by-name', 'studentName');
-
           var classStore = upgradeDb.createObjectStore( DBHelper.CLASS_STORE_NAME, {keyPath: 'classId'} );
           classStore.createIndex('by-name', 'className');
 
           var lessonStore = upgradeDb.createObjectStore( DBHelper.LESSON_STORE_NAME, {keyPath:'lessonId'} )
           lessonStore.createIndex('by-date', 'lessonDate');
           lessonStore.createIndex('by-class', 'attachedClass');
+
+          var studentStore = upgradeDb.createObjectStore( DBHelper.STUDENT_STORE_NAME, {keyPath: 'studentId'});
+          studentStore.createIndex('by-name', 'studentName');
+        case 1:
+
+          // create the new offline stores
+          var offlineClassStore = upgradeDb.createObjectStore( DBHelper.OFFLINE_CLASS_STORE_NAME, {autoIncrement:true})
+          offlineClassStore.createIndex('by-name', 'className');
+
+          var offlineLessonStore = upgradeDb.createObjectStore( DBHelper.OFFLINE_LESSON_STORE_NAME, {autoIncrement:true})
+          offlineLessonStore.createIndex('by-date', 'lessonDate');
+          offlineLessonStore.createIndex('by-name', 'className');
+          
+          var offlineStudentStore = upgradeDb.createObjectStore( DBHelper.OFFLINE_STUDENT_STORE_NAME, {autoIncrement:true})
+          offlineStudentStore.createIndex('by-name', 'studentName')
       }
     })
   }
@@ -136,6 +189,13 @@ class DBHelper{
       let tx = db.transaction(DBHelper.STUDENT_STORE_NAME);
       let classStore = tx.objectStore(DBHelper.STUDENT_STORE_NAME);
       return classStore.get(studentIndex)
+    })
+  }
+
+  // TODO: Fill out this function to get the offline key
+  getOfflineStudent(studentIndex){
+    return this.dbPromise.then(db=>{
+      let tx = db.transaction(DBHelper.OFFLINE_STUDENT_STORE_NAME)
     })
   }
 

--- a/src/scripts/DbHelper.js
+++ b/src/scripts/DbHelper.js
@@ -339,7 +339,7 @@ class DBHelper{
 
   // add offline data
 
-  addOfflineRecord(storeName, recordObject){
+  addOfflineRecord(storeName, recordObject, idLabel ='id'){
     return this.dbPromise.then((db)=>{
       let tx = db.transaction(storeName, 'readwrite');
       let listStore = tx.objectStore(storeName);
@@ -347,7 +347,7 @@ class DBHelper{
       listStore.put(recordObject).then( autoKey =>{
         listStore.openCursor(autoKey).then( cursor =>{
           if(cursor){
-            cursor.update({...cursor.value, id:DBHelper.maskOfflineIndex(cursor.key) })
+            cursor.update({...cursor.value, [idLabel]:DBHelper.maskOfflineIndex(cursor.key) })
             cursor.continue()
           }
         })
@@ -358,23 +358,29 @@ class DBHelper{
   }
 
   addOfflineClass({
-    className = DBHelper.OFFLINE_CLASS_MODEL.className
+    className = DBHelper.OFFLINE_CLASS_MODEL.className,
+    attachedStudents = DBHelper.OFFLINE_CLASS_MODEL.attachedStudents
   }){
-    this.addOfflineRecord(DBHelper.OFFLINE_CLASS_STORE_NAME, {className})
+    this.addOfflineRecord(DBHelper.OFFLINE_CLASS_STORE_NAME, {className}, "classId")
   }
 
-  // TODO: Fill out this function to get the offline key
-  getOfflineClass(offlineClassIndex){
-    return this.dbPromise
-    .then(db=>{
-      let tx = db.transaction(DBHelper.OFFLINE_CLASS_STORE_NAME);
-      let offlineClassStore = tx.objectStore(DBHelper.OFFLINE_CLASS_STORE_NAME);
-
-      let classStoreIndex = Number(DBHelper.decodeOfflineIndex(offlineClassIndex));
-
-      return offlineClassStore.get(classStoreIndex)
-    })
+  addOfflineLesson({
+    attachedClass = DBHelper.OFFLINE_LESSON_MODEL.attachedClass,
+    attachedStudents = DBHelper.OFFLINE_LESSON_MODEL.attachedStudents,
+    lessonDate = DBHelper.OFFLINE_LESSON_MODEL.lessonDate,
+    lessonName = DBHelper.OFFLINE_.LESSON_MODEL.lessonName
+  }){
+    var dateMilisecond = (lessonDate) ? new Date(lessonDate) : new Date();
+    lessonDate = dateMilisecond.valueOf();
+    this.addOfflineRecord(DBHelper.OFFLINE_LESSON_STORE_NAME, {lessonName,lessonDate, attachedClass,attachedStudents}, "lessonId" )
   }
+
+  addOfflineStudent({
+    studentName = DBHelper.OFFLINE_STUDENT_MODEL.studentName
+  }){
+    this.addOfflineRecord(DBHelper.OFFLINE_STUDENT_STORE_NAME, {studentName}, "studentId")
+  }
+
 
   // retrieve offline data
 

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -757,7 +757,6 @@ const recorderApp = function RecorderApp(){
         
         // move to the next page
         showStudentSelectPage(selectedPageName);
-        // TODO : REVERT ALL THESE CHANGES
           // seems to be working - except its a page out (e.g. title shows current page selection)
         updateStudentSelectTitle(studentSelectModel.selectedOptions);
           


### PR DESCRIPTION
# Aim
Allow users to add their own classes/lessons/students locally and mix them with network defined classes/lessons/students.

# Considerations
As
- classes contain references to students
- lessons contain references to classes and students
offline data should be able to relate to either network created/pulled classes/students or local ones

Lists of classes etc. should include both network and locally defined resources 

Initially the focus is to provide purely offline functionality BUT with a mind to the fact that eventually data will be a mixture of data from the server (with server defined class/lesson/student Ids) and local data (with locally defined class/lesson/student Ids).

# Deliverables
- [ ] Use able to add new class/lesson/students
- [ ] Display locally added classes/lessons/students