### PR TITLE
Add resource deletion

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -80,7 +80,7 @@
         </section>
       
         <section class="manage-target">
-          <div class="item-modify-item-select"></div>
+          <div class="item-modify-target-list"></div>
         </section>
 
         <section class="target-form">

--- a/src/scripts/DbHelper.js
+++ b/src/scripts/DbHelper.js
@@ -207,6 +207,8 @@ export default class DbHelper {
   }
 
 
+  // modify resources (post)
+
   modifyClass({
     classId = undefined,
     className = undefined,
@@ -235,7 +237,20 @@ export default class DbHelper {
     return this.clientDataHelper.modifyStudent(arguments[0])
   }
 
-  // post methods (udpate) post TO somewhere
+
+  // delete resources
+
+  deleteClass( classId ){
+    return this.clientDataHelper.deleteClass( classId )
+  }
+
+  deleteLesson( lessonId ){
+    return this.clientDataHelper.deleteLesson( lessonId )
+  }
+
+  deleteStudent( studentId ){
+    return this.clientDataHelper.deleteStudent( studentId )
+  }
 
   // populate functions
 

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -925,6 +925,13 @@ const recorderApp = function RecorderApp(){
                 classObject
               })
             })
+            // change form button from create to modify
+            .then( formElement =>{
+              let submitButton = formElement.querySelector('button[type=submit]')
+              submitButton.innerText = "Modify Class"
+
+              return formElement;
+            })
           })
           // add the form to the container
           .then( formElement =>{
@@ -977,6 +984,13 @@ const recorderApp = function RecorderApp(){
                 lessonObject
               })
             })
+            // change form button from create to modify
+            .then( formElement =>{
+              let submitButton = formElement.querySelector('button[type=submit]')
+              submitButton.innerText = "Modify Lesson"
+
+              return formElement;
+            })
           })
           // add the from element to the page
           .then( formElement => container.appendChild(formElement))
@@ -1014,6 +1028,13 @@ const recorderApp = function RecorderApp(){
           .then( studentObject =>{
             let studentForm = generateItemCreateForm('student', submitCallback, deleteCallback );
             return ItemCreateHelper.prefillForm({generatedForm: studentForm, studentObject})
+          })
+          // change form button from create to modify
+          .then( formElement =>{
+            let submitButton = formElement.querySelector('button[type=submit]')
+            submitButton.innerText = "Modify Student"
+
+            return formElement;
           })
           // attached filled form to the document
           .then( filledForm =>{

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -382,7 +382,6 @@ const recorderApp = function RecorderApp(){
     return filterSection;
   }
 
-
   const fillOptions = ({fillPage, selectedClass, selectedOptions})=>{
     var options;
 
@@ -755,7 +754,7 @@ const recorderApp = function RecorderApp(){
 
   // ITEM MANAGEMENT FORMS
 
-  const generateItemCreateForm = (itemCreateType, submitCallback)=>{
+  const generateItemCreateForm = (itemCreateType, submitCallback, deleteCallback)=>{
     // fill with appropriate form
     switch(itemCreateType){
       case 'class':
@@ -769,7 +768,7 @@ const recorderApp = function RecorderApp(){
           })
         // return the class form
         }).then( studentOptions =>{
-          return ItemCreateHelper.generateClassForm({ studentOptions, submitCallback })
+          return ItemCreateHelper.generateClassForm({ studentOptions, submitCallback, deleteCallback })
         })
       break;
       case 'lesson':
@@ -786,14 +785,15 @@ const recorderApp = function RecorderApp(){
         .then( optionObjects =>{
           return ItemCreateHelper.generateLessonForm({
             classOptions: optionObjects,
-            submitCallback
+            submitCallback,
+            deleteCallback
           })
         })
         
       break;  
       case 'student':
         // return the student form 
-        return ItemCreateHelper.generateStudentForm({submitCallback});
+        return ItemCreateHelper.generateStudentForm({submitCallback, deleteCallback});
       break;
       default: throw new Error(`No recognised item type: ${itemCreateType}`)
     }
@@ -880,6 +880,7 @@ const recorderApp = function RecorderApp(){
 
     let container;
     let submitCallback;
+    let deleteCallback;
 
     // fill with appropriate form
     switch(itemModifyType){
@@ -896,9 +897,21 @@ const recorderApp = function RecorderApp(){
             showItemManageMessage(`Class not updated: ${err.message}`)
           })
         }
-        
+
+        deleteCallback = ( event )=>{
+          event.preventDefault();
+          
+          if(window.confirm(`Are you sure you want to delete?`)){
+            dbHelper.deleteClass(itemId)
+            .then( ()=>{
+              showItemManageMessage(`item deleted`);
+              updateModifyOptions('class');
+            })
+          }
+        }
+
         // get the form
-        generateItemCreateForm('class', submitCallback)
+        generateItemCreateForm('class', submitCallback, deleteCallback)
         // pre-fill the form with class details
         .then( classCreateForm =>{
           // get the class
@@ -910,28 +923,6 @@ const recorderApp = function RecorderApp(){
               classObject
             })
           })
-        })
-        // add a button to delete the resource
-        .then( formElement =>{
-          var deleteButton = document.createElement('button');
-
-          deleteButton.classList.add('item-delete');
-          deleteButton.innerText = "Delete Class"
-          deleteButton.addEventListener('click', ( event )=>{
-            event.preventDefault();
-            
-            if(window.confirm(`Are you sure you want to delete?`)){
-              dbHelper.deleteClass(itemId)
-              .then( ()=>{
-                showItemManageMessage(`item deleted`);
-                updateModifyOptions('class');
-              })
-            }
-          })
-
-          formElement.appendChild(deleteButton)
-
-          return formElement;
         })
         // add the form to the container
         .then( formElement =>{
@@ -958,8 +949,20 @@ const recorderApp = function RecorderApp(){
 
         }
 
+        deleteCallback = (event) => {
+          event.preventDefault();
+          
+          if(window.confirm(`Are you sure you want to delete?`)){
+            dbHelper.deleteLesson(itemId)
+            .then( ()=>{
+              showItemManageMessage(`item deleted`);
+              updateModifyOptions('lesson');
+            })
+          }
+        }
+
         // get the student form
-        generateItemCreateForm('lesson', submitCallback)
+        generateItemCreateForm('lesson', submitCallback, deleteCallback)
         // prefill the lesson values in the form
         .then( lessonCreateForm =>{
           // get the lessonObject to pre-fill
@@ -989,11 +992,23 @@ const recorderApp = function RecorderApp(){
           })
         }
 
+        deleteCallback = ( event ) =>{
+          event.preventDefault();
+          
+          if(window.confirm(`Are you sure you want to delete?`)){
+            dbHelper.deleteStudent(itemId)
+            .then( ()=>{
+              showItemManageMessage(`item deleted`);
+              updateModifyOptions('student');
+            })
+          }
+        }
+
         // get the student
         dbHelper.getStudent({ studentId: itemId })
         // generate the form & combine with student object
         .then( studentObject =>{
-          let studentForm = generateItemCreateForm('student', submitCallback);
+          let studentForm = generateItemCreateForm('student', submitCallback, deleteCallback );
           return ItemCreateHelper.prefillForm({generatedForm: studentForm, studentObject})
         })
         // attached filled form to the document

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -45,7 +45,7 @@ const recorderApp = function RecorderApp(){
   var itemCreateTabBody = document.querySelector('.tab-body.item-create');
   var itemCreateTypeDropdown = document.querySelector('.tab-body.item-create .item-create-type-dropdown');
   var itemCreateOperationDropdown = document.querySelector('.tab-body.item-create .item-create-operation-dropdown');
-  var itemModifyItemSelect = document.querySelector('.tab-body.item-create .item-modify-item-select');
+  var modifyItemTargetList = document.querySelector('.tab-body.item-create .item-modify-target-list');
   var itemMangementMessageDisplay = document.querySelector('.tab-body.item-create .message-display');
 
 
@@ -752,7 +752,7 @@ const recorderApp = function RecorderApp(){
     emptyHTML(itemMangementMessageDisplay);
   }
 
-  // ITEM MANAGEMENT FORMS
+  // ITEM MANAGEMENT FORM FUNCTIONS
 
   const generateItemCreateForm = (itemCreateType, submitCallback, deleteCallback)=>{
     // fill with appropriate form
@@ -799,7 +799,7 @@ const recorderApp = function RecorderApp(){
     }
   }
 
-  const updateItemCreate =  (itemCreateType)=>{
+  const updateItemCreateForm =  (itemCreateType)=>{
 
     // clear all the containers
     document.querySelectorAll('.item-create-form').forEach(emptyHTML);
@@ -873,7 +873,7 @@ const recorderApp = function RecorderApp(){
     
   }
 
-  const updateItemCreateModify = (itemModifyType, itemId)=>{
+  const updateItemModifyForm = (itemModifyType, itemId)=>{
     
     // clear all the containers
     document.querySelectorAll('.item-create-form').forEach(emptyHTML);
@@ -882,160 +882,166 @@ const recorderApp = function RecorderApp(){
     let submitCallback;
     let deleteCallback;
 
-    // fill with appropriate form
-    switch(itemModifyType){
-      case 'class':
-        container = document.querySelector('.item-create-form.class');
+    // fill with appropriate form if a id is defined
+    if( itemId != undefined){
+      switch(itemModifyType){
+        case 'class':
+          container = document.querySelector('.item-create-form.class');
 
-        // submit callback
-        submitCallback = ({ className, attachedStudents})=>{
-          dbHelper.modifyClass({classId: itemId, className, attachedStudents})
-          .then(()=>{
-            showItemManageMessage(`Class updated: ${className}`)
-            updateModifyOptions('class')
-          }, ( err ) =>{
-            showItemManageMessage(`Class not updated: ${err.message}`)
-          })
-        }
-
-        deleteCallback = ( event )=>{
-          event.preventDefault();
-          
-          if(window.confirm(`Are you sure you want to delete?`)){
-            dbHelper.deleteClass(itemId)
-            .then( ()=>{
-              showItemManageMessage(`item deleted`);
-              updateModifyOptions('class');
+          // submit callback
+          submitCallback = ({ className, attachedStudents})=>{
+            dbHelper.modifyClass({classId: itemId, className, attachedStudents})
+            .then(()=>{
+              showItemManageMessage(`Class updated: ${className}`)
+              updateModifyTargetList('class', itemId)
+            }, ( err ) =>{
+              showItemManageMessage(`Class not updated: ${err.message}`)
             })
           }
-        }
 
-        // get the form
-        generateItemCreateForm('class', submitCallback, deleteCallback)
-        // pre-fill the form with class details
-        .then( classCreateForm =>{
-          // get the class
-          return dbHelper.getClass({classId: itemId})
-          // combine the class Object with the form
-          .then( classObject =>{
-            return ItemCreateHelper.prefillForm({
-              generatedForm: classCreateForm,
-              classObject
+          deleteCallback = ( event )=>{
+            event.preventDefault();
+            
+            if(window.confirm(`Are you sure you want to delete?`)){
+              dbHelper.deleteClass(itemId)
+              .then( ()=>{
+                showItemManageMessage(`item deleted`);
+                updateModifyTargetList('class');
+                updateItemModifyForm('class')
+              })
+            }
+          }
+
+          // get the form
+          generateItemCreateForm('class', submitCallback, deleteCallback)
+          // pre-fill the form with class details
+          .then( classCreateForm =>{
+            // get the class
+            return dbHelper.getClass({classId: itemId})
+            // combine the class Object with the form
+            .then( classObject =>{
+              return ItemCreateHelper.prefillForm({
+                generatedForm: classCreateForm,
+                classObject
+              })
             })
           })
-        })
-        // add the form to the container
-        .then( formElement =>{
-          container.appendChild(formElement)
-        })
-      break;
-      case 'lesson':
-        container = document.querySelector('.item-create-form.lesson');
+          // add the form to the container
+          .then( formElement =>{
+            container.appendChild(formElement)
+          })
+        break;
+        case 'lesson':
+          container = document.querySelector('.item-create-form.lesson');
 
-        submitCallback = ({lessonName, lessonDate, attachedClass})=>{
+          submitCallback = ({lessonName, lessonDate, attachedClass})=>{
+          
+            // get the attached class' student to add to the lesson
+            dbHelper.getClass({classId: attachedClass})
+            // modify the lesson object in memory
+            .then( ({attachedStudents}) =>{
+              dbHelper.modifyLesson({lessonId:itemId,lessonName, lessonDate, attachedClass, attachedStudents })
+            })
+            .then(()=>{
+              showItemManageMessage(`Lesson updated: ${lessonName}`)
+              updateModifyTargetList('lesson', itemId)
+            }, ( err ) =>{
+              showItemManageMessage(`Lesson not updated: ${err.message}`)
+            })
+
+          }
+
+          deleteCallback = (event) => {
+            event.preventDefault();
+            
+            if(window.confirm(`Are you sure you want to delete?`)){
+              dbHelper.deleteLesson(itemId)
+              .then( ()=>{
+                showItemManageMessage(`item deleted`);
+                updateModifyTargetList('lesson');
+                updateItemModifyForm('lesson')
+              })
+            }
+          }
+
+          // get the student form
+          generateItemCreateForm('lesson', submitCallback, deleteCallback)
+          // prefill the lesson values in the form
+          .then( lessonCreateForm =>{
+            // get the lessonObject to pre-fill
+            return dbHelper.getLesson({ lessonId: itemId })
+            // combine the lesson object with the form
+            .then( lessonObject =>{
+              return ItemCreateHelper.prefillForm({
+                generatedForm: lessonCreateForm,
+                lessonObject
+              })
+            })
+          })
+          // add the from element to the page
+          .then( formElement => container.appendChild(formElement))
+          
+        break;  
+        case 'student':
+          container = document.querySelector('.item-create-form.student');
+
+          submitCallback = ({studentName})=>{
+            dbHelper.modifyStudent({ studentId:itemId, studentName })
+            .then(()=>{
+              showItemManageMessage(`Student updated: ${studentName}`);
+              updateModifyTargetList('student', itemId)
+            }, ( err ) =>{
+              showItemManageMessage(`Student not modified: ${err.message}`)
+            })
+          }
+
+          deleteCallback = ( event ) =>{
+            event.preventDefault();
+            
+            if(window.confirm(`Are you sure you want to delete?`)){
+              dbHelper.deleteStudent(itemId)
+              .then( ()=>{
+                showItemManageMessage(`item deleted`);
+                updateModifyTargetList('student');
+                updateItemModifyForm('student')
+              })
+            }
+          }
+
+          // get the student
+          dbHelper.getStudent({ studentId: itemId })
+          // generate the form & combine with student object
+          .then( studentObject =>{
+            let studentForm = generateItemCreateForm('student', submitCallback, deleteCallback );
+            return ItemCreateHelper.prefillForm({generatedForm: studentForm, studentObject})
+          })
+          // attached filled form to the document
+          .then( filledForm =>{
+            container.appendChild(filledForm);
+          })
+
         
-          // get the attached class' student to add to the lesson
-          dbHelper.getClass({classId: attachedClass})
-          // modify the lesson object in memory
-          .then( ({attachedStudents}) =>{
-            dbHelper.modifyLesson({lessonId:itemId,lessonName, lessonDate, attachedClass, attachedStudents })
-          })
-          .then(()=>{
-            showItemManageMessage(`Lesson updated: ${lessonName}`)
-            updateModifyOptions('lesson')
-          }, ( err ) =>{
-            showItemManageMessage(`Lesson not updated: ${err.message}`)
-          })
-
-        }
-
-        deleteCallback = (event) => {
-          event.preventDefault();
-          
-          if(window.confirm(`Are you sure you want to delete?`)){
-            dbHelper.deleteLesson(itemId)
-            .then( ()=>{
-              showItemManageMessage(`item deleted`);
-              updateModifyOptions('lesson');
-            })
-          }
-        }
-
-        // get the student form
-        generateItemCreateForm('lesson', submitCallback, deleteCallback)
-        // prefill the lesson values in the form
-        .then( lessonCreateForm =>{
-          // get the lessonObject to pre-fill
-          return dbHelper.getLesson({ lessonId: itemId })
-          // combine the lesson object with the form
-          .then( lessonObject =>{
-            return ItemCreateHelper.prefillForm({
-              generatedForm: lessonCreateForm,
-              lessonObject
-            })
-          })
-        })
-        // add the from element to the page
-        .then( formElement => container.appendChild(formElement))
-        
-      break;  
-      case 'student':
-        container = document.querySelector('.item-create-form.student');
-
-        submitCallback = ({studentName})=>{
-          dbHelper.modifyStudent({ studentId:itemId, studentName })
-          .then(()=>{
-            showItemManageMessage(`Student updated: ${studentName}`);
-            updateModifyOptions('student')
-          }, ( err ) =>{
-            showItemManageMessage(`Student not modified: ${err.message}`)
-          })
-        }
-
-        deleteCallback = ( event ) =>{
-          event.preventDefault();
-          
-          if(window.confirm(`Are you sure you want to delete?`)){
-            dbHelper.deleteStudent(itemId)
-            .then( ()=>{
-              showItemManageMessage(`item deleted`);
-              updateModifyOptions('student');
-            })
-          }
-        }
-
-        // get the student
-        dbHelper.getStudent({ studentId: itemId })
-        // generate the form & combine with student object
-        .then( studentObject =>{
-          let studentForm = generateItemCreateForm('student', submitCallback, deleteCallback );
-          return ItemCreateHelper.prefillForm({generatedForm: studentForm, studentObject})
-        })
-        // attached filled form to the document
-        .then( filledForm =>{
-          container.appendChild(filledForm);
-        })
-
-       
-      break;
-      default: throw new Error(`No recognised item type: ${itemCreateType}`)
+        break;
+        default: throw new Error(`No recognised item type: ${itemCreateType}`)
+      }
     }
   }
 
-  const itemCreateDropdownCallback = ()=>{
+  const itemManageDrowdownCallback = ()=>{
 
     var operationType = itemCreateOperationDropdown.value;
     var itemType = itemCreateTypeDropdown.value;
 
-    emptyHTML(itemModifyItemSelect);
-    clearItemManageMessage()
+    emptyHTML(modifyItemTargetList); // empty the itemModify targets
+    clearItemManageMessage() // clear the message
     
     switch(operationType){
       case 'create':
-        updateItemCreate(itemType)
+        updateItemCreateForm(itemType)
       break;
       case 'modify':
-        updateModifyOptions(itemType)
+        document.querySelectorAll('.item-create-form').forEach(emptyHTML);  // empty the form area
+        updateModifyTargetList(itemType)
       break;
       default:
         console.log(`unknown operation ${operationType}`)
@@ -1043,7 +1049,7 @@ const recorderApp = function RecorderApp(){
     }  
   }
 
-  const updateModifyOptions = (itemModifyType)=>{
+  const updateModifyTargetList = (itemModifyType, selectedItemId)=>{
     
     var optionObjects;
     
@@ -1084,22 +1090,23 @@ const recorderApp = function RecorderApp(){
       var itemSelectCallback = (event)=>{
         [...event.target.parentNode.children].forEach( element => element.checked = false)
         event.target.checked = true;
-        updateItemCreateModify(itemModifyType, event.target.value)
+        updateItemModifyForm(itemModifyType, event.target.value)
       }
 
       return generateOptionElements({
         optionLabel: 'modify-item-select',
         optionList: optionObjects,
-        clickFunction: itemSelectCallback
+        clickFunction: itemSelectCallback,
+        selectedOptions: [selectedItemId]
       })
     })
     // add it to the document
     .then( optionElements =>{
       // remove the old options
-      emptyHTML(itemModifyItemSelect)
+      emptyHTML(modifyItemTargetList)
       // add the new
       optionElements.forEach( element =>{
-        itemModifyItemSelect.appendChild(element)
+        modifyItemTargetList.appendChild(element)
       })
     })
 
@@ -1119,7 +1126,7 @@ const recorderApp = function RecorderApp(){
     updateStudentSelectDisplay(studentSelectModel.getSelectedOptions());
     // update the clip filter display
     updateFilterDisplay()
-    updateItemCreate('class');
+    updateItemCreateForm('class');
   })
 
   // set up the media recorder
@@ -1233,15 +1240,15 @@ const recorderApp = function RecorderApp(){
     updateClipList({searchType: filterType, searchKey})
   }
 
-  itemCreateTypeDropdown.addEventListener('change', itemCreateDropdownCallback);
-  itemCreateOperationDropdown.addEventListener('change', itemCreateDropdownCallback);
+  itemCreateTypeDropdown.addEventListener('change', itemManageDrowdownCallback);
+  itemCreateOperationDropdown.addEventListener('change', itemManageDrowdownCallback);
 
   return {
     dbHelper,
     studentSelectModel,
     updateFilterDisplay,
-    updateItemCreate,
-    updateItemCreateModify,
+    updateItemCreate: updateItemCreateForm,
+    updateItemCreateModify: updateItemModifyForm,
     showItemManageMessage,
     clearItemManageMessage
   }

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -896,6 +896,7 @@ const recorderApp = function RecorderApp(){
             showItemManageMessage(`Class not updated: ${err.message}`)
           })
         }
+        
         // get the form
         generateItemCreateForm('class', submitCallback)
         // pre-fill the form with class details
@@ -909,6 +910,28 @@ const recorderApp = function RecorderApp(){
               classObject
             })
           })
+        })
+        // add a button to delete the resource
+        .then( formElement =>{
+          var deleteButton = document.createElement('button');
+
+          deleteButton.classList.add('item-delete');
+          deleteButton.innerText = "Delete Class"
+          deleteButton.addEventListener('click', ( event )=>{
+            event.preventDefault();
+            
+            if(window.confirm(`Are you sure you want to delete?`)){
+              dbHelper.deleteClass(itemId)
+              .then( ()=>{
+                showItemManageMessage(`item deleted`);
+                updateModifyOptions('class');
+              })
+            }
+          })
+
+          formElement.appendChild(deleteButton)
+
+          return formElement;
         })
         // add the form to the container
         .then( formElement =>{

--- a/src/scripts/modules/ClientDataHelper.js
+++ b/src/scripts/modules/ClientDataHelper.js
@@ -73,7 +73,7 @@ class ClientDataHelper{
   }
 
   static revealId(maskedIndex){
-    return maskedIndex.replace(/#/g, "");
+    return Number(maskedIndex.replace(/#/g, ""));
   }
 
   // get methods
@@ -323,6 +323,28 @@ class ClientDataHelper{
 
     return modifyRecord( 'clip', clipId, updateValues )
   }
+
+  deleteRecord( objectType , objectId ){
+    return this.dbPromise.then( db =>{
+      let tx = db.transaction( ClientDataHelper.STORE_NAMES[ objectType ], 'readwrite' );
+      let objectStore = tx.objectStore( ClientDataHelper.STORE_NAMES[ objectType ] );
+
+      objectStore.delete( ClientDataHelper.revealId(objectId) )
+    })
+  }
+
+  deleteClass( classId ){
+    return this.deleteRecord('class', classId)
+  }
+
+  deleteLesson( lessonId ){
+    return this.deleteRecord('lesson', lessonId)
+  }
+
+  deleteStudent( studentId ){
+    return this.deleteRecord('student', studentId)
+  }
+  
 
   populateTestData(){
     this.addClass({className:"Test Class 1", attachedStudents:['2','#1'] });

--- a/src/scripts/modules/ClientDataHelper.js
+++ b/src/scripts/modules/ClientDataHelper.js
@@ -325,11 +325,12 @@ class ClientDataHelper{
   }
 
   deleteRecord( objectType , objectId ){
-    return this.dbPromise.then( db =>{
+    return this.dbPromise
+    .then( db =>{
       let tx = db.transaction( ClientDataHelper.STORE_NAMES[ objectType ], 'readwrite' );
       let objectStore = tx.objectStore( ClientDataHelper.STORE_NAMES[ objectType ] );
 
-      objectStore.delete( ClientDataHelper.revealId(objectId) )
+      return objectStore.delete( ClientDataHelper.revealId(objectId) )
     })
   }
 
@@ -344,6 +345,7 @@ class ClientDataHelper{
   deleteStudent( studentId ){
     return this.deleteRecord('student', studentId)
   }
+
   
 
   populateTestData(){

--- a/src/scripts/modules/ItemCreateHelper.js
+++ b/src/scripts/modules/ItemCreateHelper.js
@@ -6,7 +6,8 @@ export default class ItemCreateHelper{
   static generateClassForm({
     studentOptions= [],
     existingClassObject= {},
-    submitCallback = console.log
+    submitCallback = console.log,
+    deleteCallback
   }={}){
     const form = document.createElement('form');
     const submitButton = document.createElement('button');
@@ -48,13 +49,27 @@ export default class ItemCreateHelper{
     submitButton.innerText = "Create Class";
     form.appendChild(submitButton);
 
+    // add delete button if needed
+    if(deleteCallback != undefined){
+      const deleteButton = document.createElement('button');
+
+      deleteButton.classList.add('item-delete');
+      deleteButton.innerText = "Delete Class"
+      deleteButton.addEventListener('click', deleteCallback)
+
+      form.appendChild(deleteButton)
+    }
+
+    
+
     return form;
   }
 
 
   static generateLessonForm({
     classOptions = [],
-    submitCallback = console.log
+    submitCallback = console.log,
+    deleteCallback
   }={}){
 
     const form = document.createElement('form');
@@ -94,11 +109,22 @@ export default class ItemCreateHelper{
     submitButton.innerText = "Create Lesson";
     form.appendChild(submitButton);
 
+    if(deleteCallback != undefined){
+      const deleteButton = document.createElement('button');
+
+      deleteButton.classList.add('item-delete');
+      deleteButton.innerText = "Delete Lesson"
+      deleteButton.addEventListener('click',deleteCallback)
+
+      form.appendChild(deleteButton)
+    }
+
     return form;
   }
 
   static generateStudentForm({
-    submitCallback = console.log
+    submitCallback = console.log,
+    deleteCallback
   }={}){
     const form = document.createElement('form');
     const submitButton = document.createElement('button')
@@ -125,6 +151,17 @@ export default class ItemCreateHelper{
     submitButton.type = 'submit';
     submitButton.innerText = "Create Student";
     form.appendChild(submitButton);
+
+    // add delete button if needed
+    if(deleteCallback != undefined){
+      const deleteButton = document.createElement('button');
+
+      deleteButton.classList.add('item-delete');
+      deleteButton.innerText = "Delete Student"
+      deleteButton.addEventListener('click', deleteCallback )
+
+      form.appendChild(deleteButton)
+    }
 
     return form;
   }

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -1,6 +1,7 @@
-$ex-large-font: 1.5em;
-$large-font: 1.2em;
-$small-font: 0.75em;
+$ex-large-font: 1.5rem;
+$large-font: 1.2rem;
+$normal-font: 1rem;
+$small-font: 0.75rem;
 
 html{
     height:100vh;
@@ -339,7 +340,7 @@ body{
       display:block;
     }
 
-    input{
+    input, select{
       padding:0.5em 1em;
       margin-bottom:1em;
       text-align:center;
@@ -352,6 +353,10 @@ body{
       margin-right:auto;
       padding:0.75em;
       display:block;
+    }
+
+    button.item-delete{
+      font-size: $normal-font;
     }
   }
 

--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -307,7 +307,7 @@ body{
   }
 
   .manage-target{
-    .item-modify-item-select{
+    .item-modify-target-list{
       display:flex;
       flex-direction:column;
 

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -188,7 +188,7 @@ nav{
     border-radius: 50px;
 
     .manage-target{
-      .item-modify-item-select{
+      .item-modify-target-list{
         color:$sec-text;
   
         input[type="checkbox"]:checked+label{

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -214,6 +214,11 @@ nav{
         outline: none;
         border-color:$pri-text;
       }
+
+      button.item-delete{
+        background-color: $box-color;
+        color:$manage-dark-pri;
+      }
     }
 
   }


### PR DESCRIPTION
# Aim
Allow users to remove local resources they have created

# Implementation

ClientDataHelper.js
- Added deleteRecord and accompanying deleteClass/Lesson/Student functions

DbHelper.js
- Added deleteClass/Lesson/Student functions taking the Id string of the local resource

App.js
- Changed some function/variable names to make their purpose clearer
- updateItemModifyForm() defines a delete callback that is attached to the delete button in the form - calling the dbHelper deleteClass/Lesson/Student function

ItemCreateHelper.js
- generateClassForm() now takes a delete callback (generating a delete button if necessary)

UI Changes
- modifyItemForm cleared on dropdown selection
- After item modification target list shows item still selected
- After deletion modifyItemForm cleared and targetList updated

# Final look
![image](https://user-images.githubusercontent.com/3187001/55962473-d87dfb80-5c68-11e9-8ee7-d6131c2b33d6.png)
